### PR TITLE
adding support for configurable key codes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,4 +2,4 @@
 from .controller import RoonController
 from .token import RoonToken
 from .zone import RoonZone
-from .config import RemoteConfig
+from .config import RemoteConfig, RemoteConfigE, RemoteKeycodeMapping

--- a/app/config.py
+++ b/app/config.py
@@ -1,17 +1,70 @@
 
 import json
 from json import JSONDecodeError
-from typing import Dict
+from typing import Dict, List
 from pathlib import Path
+import logging
+
+logging.getLogger('RemoteConfig')
+
+
+class RemoteConfigE(BaseException):
+    """ implement a basic exception for config related issues"""
+
+    def __init__(self, msg):
+        super(RemoteConfigE, self).__init__()
+        self.msg = msg
+
+
+class RemoteKeycodeMapping:
+    """
+    contains the configured mapping from keyboard codes to Roon transport actions
+    """
+    EDGE_UP = "UP"
+    EDGE_DOWN = "DOWN"
+
+    def __init__(self, mapping_dict: Dict):
+        if 'codes' not in mapping_dict.keys():
+            raise RemoteConfigE('codes not found')
+        self._dict = mapping_dict
+        if 'edge' not in mapping_dict.keys():
+            logging.info('no "edge" config detected, setting default UP ')
+            self._dict['edge'] = self.EDGE_UP
+
+    @property
+    def edge(self) -> str:
+        key_name = "edge"
+        if key_name not in self._dict.keys():
+            raise RemoteConfigE('no key "edge" detected in config')
+        return self._dict[key_name]
+
+    def to_key_code(self, transport_action: str) -> List[int]:
+        """
+        convert transport action into key codes
+
+        Args:
+            transport_action (str): one of 'play', 'stop', 'skip', 'prev', 'playpause'
+        """
+        if 'codes' not in self._dict.keys():
+            raise RemoteConfigE('no "codes" key found')
+
+        if transport_action not in self._dict['codes'].keys():
+            raise RemoteConfigE(f'no {transport_action} key found')
+
+        return self._dict['codes'][transport_action]
 
 
 class RemoteConfig:
+    """
+    Provides an interface to the config file structure
+    """
 
-    def __init__(self, path: Path):
+    def __init__(self, path_config_file: Path):
         super(RemoteConfig).__init__()
-        if not path.exists():
-            raise Exception('invalid path given')
-        self._config = RemoteConfig._read_as_json(path)
+        if not path_config_file.exists():
+            raise RemoteConfigE('RemoteConfig, invalid path given: {}'.format(path_config_file))
+        self._config = RemoteConfig._read_as_json(path_config_file)['roon']
+        logging.debug('successfully read config from %s', path_config_file)
 
     @staticmethod
     def _read_as_json(path: Path) -> Dict:
@@ -26,8 +79,13 @@ class RemoteConfig:
 
     @property
     def app_info(self):
-        return self._config['roon']['app_info']
+        return self._config['app_info']
 
     @property
     def zone(self):
-        return self._config['roon']['zone']['name']
+        return self._config['zone']['name']
+
+    @property
+    def key_mapping(self) -> RemoteKeycodeMapping:
+        """return a keycode mapping object"""
+        return RemoteKeycodeMapping(self._config['event_mapping'])

--- a/app/token.py
+++ b/app/token.py
@@ -31,7 +31,6 @@ class RoonToken:
     def set(self, token: str) -> None:
         """set the token and write"""
         with self._path.open('w') as f:
-            print('==> written to file %s' % self._path)
             f.write(token)
 
     def __str__(self):

--- a/config/app_info.json
+++ b/config/app_info.json
@@ -3,6 +3,16 @@
 		"zone": {
 			"name": "Wohnzimmer"
 		},
+		"event_mapping": {
+			"edge": "UP",
+			"codes": {
+				"prev": [51],
+				"skip": [52],
+				"stop": [45],
+				"play": [42],
+				"play_pause": [57]
+			}
+		},
 		"app_info": {
 			"extension_id": "python_roon_remote",
 			"display_name": "Roon IR Remote",

--- a/deployment/inventory.yml
+++ b/deployment/inventory.yml
@@ -1,0 +1,3 @@
+
+[roon]
+roon-br-livingroom.home.mangelsen.se

--- a/deployment/roon-remote.service
+++ b/deployment/roon-remote.service
@@ -1,0 +1,17 @@
+
+[Unit]
+Description=Roon IR Remote Receiver
+After=multi-user.target
+
+[Service]
+Type=simple
+User=roon-remote
+Group=roon-remote
+PIDFile=/run/roon-remote.pid
+WorkingDirectory=/opt/roon-remote
+ExecStart=/usr/bin/python3 /opt/roon-remote/roon_remote.py
+ExecStop=/bin/kill -- $MAINPID
+TimeoutStopSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/deployment/site.yml
+++ b/deployment/site.yml
@@ -1,0 +1,65 @@
+---
+
+- name: Network Getting Started First Playbook
+  gather_facts: false
+  hosts: roon
+  tasks:
+
+    - name: Create a group
+      group:
+        name: roon-remote
+        state: present
+
+    - name: Create a user
+      user:
+        name: roon-remote
+        comment: Roon Remote User
+        groups:
+          - roon-remote
+          - input
+
+    - name: Remove Installation Folder
+      file:
+        dest: /opt/roon-remote/
+        state: absent
+
+    - name: Git checkout
+      tags:
+        - sebman
+      git:
+        repo: 'https://github.com/smangels/rasp-zero-roon-controller.git'
+        dest: /opt/roon-remote
+        version: 0.1.1
+        force: true
+
+
+    - name: Ensure that empty token exists
+      file:
+        dest: /opt/roon-remote/.roon-token
+        state: touch
+
+    - name: Chown Installation Folder
+      file:
+        dest: /opt/roon-remote/
+        state: directory
+        recurse: true
+        owner: roon-remote
+        group: roon-remote
+        mode: '770'
+
+
+    - name: PIP install required packages
+      pip:
+        name: [ 'roonapi', 'evdev' ]
+        state: present
+
+    - name: Copy systemd service file
+      copy:
+        src: roon-remote.service
+        dest: /etc/systemd/system/roon-remote.service
+
+    - name: Enable and start the service
+      systemd:
+        name: roon-remote.service
+        daemon_reload: true
+        state: restarted


### PR DESCRIPTION
- map transport actions to key codes
- config provides a new class that supports
  converting transport actions into key codes
  thus a user could easy map existing FLIRC
  setups to Roon transport actions (e.g "play", "pause")

provide Ansible config

remove old print message

logging - print path instead of name